### PR TITLE
Update CargocultDailyPriceLevels.cs

### DIFF
--- a/Indicators/CargocultIndicators/CargocultDailyPriceLevels.cs
+++ b/Indicators/CargocultIndicators/CargocultDailyPriceLevels.cs
@@ -84,7 +84,7 @@
 						maxLevels = Math.Max(levels.Length, maxLevels);
 						foreach(string level in levels)
 						{				
-							_levelsByDate[date.Date].Add(double.Parse(level));
+							_levelsByDate[date.Date].Add(double.Parse(level, culture));
 						}
 						line = reader.ReadLine();
 					}


### PR DESCRIPTION
Update dataimport for foreign "cultures" e.g. in Europe with an other use of the "," and "." in their number system.
Without forcing to use using us-en it doesn't import data like "1234.00, 2345.25, ..."