### PR TITLE
add carry forward levels and lookup cache

### DIFF
--- a/Indicators/CargocultIndicators/CargocultDailyPriceLevels.cs
+++ b/Indicators/CargocultIndicators/CargocultDailyPriceLevels.cs
@@ -22,10 +22,11 @@
 	using NinjaTrader.NinjaScript;
 	using NinjaTrader.Core.FloatingPoint;
 	using NinjaTrader.NinjaScript.DrawingTools;
+	using System.Linq;
 	// Manually added:
 	using System.IO;
 	#endregion
-
+	
 	//This namespace holds Indicators in this folder and is required. Do not change it. 
 	namespace NinjaTrader.NinjaScript.Indicators
 	{
@@ -33,14 +34,20 @@
 		public class CargocultDailyPriceLevels : Indicator
 		{
 			#region Variables
-			private Dictionary<DateTime, List<double>> _levelsByDate;
+			private SortedDictionary<DateTime, List<double>> _levelsByDate;
+			private Dictionary<DateTime, KeyValuePair<DateTime, List<double>>> _chartDateToLevelsDateCache;
 			private DateTime _lastFileModifiedDate;
 			private long _lastMaxLevels;
-			private static string version = "1.5.1";
+			private static string version = "1.6.0";
 			private Series<double> currentUpperLevel;
 			private Series<double> currentLowerLevel;
 			#endregion
 			
+			private void resetCache()
+			{
+				Log("Resetting chart date to level date cache", LogLevel.Information);
+				_chartDateToLevelsDateCache = new Dictionary<DateTime, KeyValuePair<DateTime, List<double>>>();
+			}
 			private void readCSV(string filename)
 			{
 				/* 
@@ -67,7 +74,9 @@
 					return;;
 				}
 				_lastFileModifiedDate = fileModifiedDate;
-				_levelsByDate = new Dictionary<DateTime, List<double>>();	
+				_levelsByDate = new SortedDictionary<DateTime, List<double>>();	
+				// reset cache as mapping may be invalid with new file
+				resetCache();
 				long maxLevels = 0;
 				using(StreamReader reader = new StreamReader(resolved_filename))
 				{
@@ -86,6 +95,7 @@
 						{				
 							_levelsByDate[date.Date].Add(double.Parse(level, culture));
 						}
+						
 						line = reader.ReadLine();
 					}
 				}
@@ -114,6 +124,10 @@
 					LevelLineWidth = 2;
 					LevelLineOpacity = 50;
 					LevelLineType = DashStyleHelper.Dot;
+					MaxDayCarryForward = 1;
+					VerboseLogging = false;
+					// todo - cargo - figure out if this is the best place for a reset of cache
+					resetCache();
 					Log("Daily Price Levels by Cargocult version " + version, LogLevel.Information);
 				}
 				else if (State == State.Configure)
@@ -134,20 +148,66 @@
 				}
 			}
 
+			private KeyValuePair<DateTime, List<double>> getLevelsForDate()
+			{
+				var currentDate = Time[0].Date;
+				if(_chartDateToLevelsDateCache.ContainsKey(currentDate))
+				{
+					return _chartDateToLevelsDateCache[currentDate];
+				}
+				else 
+				{
+					var kv = _levelsByDate.LastOrDefault(x => ( x.Key <= currentDate && (currentDate - x.Key).Days <= MaxDayCarryForward) );
+					_chartDateToLevelsDateCache[currentDate] = kv;
+					var levelsFileDate = kv.Key;
+					var logLevel = levelsFileDate == currentDate ? LogLevel.Information : levelsFileDate < currentDate ? LogLevel.Warning : LogLevel.Error;
+					Log(String.Format("Using file level date: {0} for chart date: {1} maxDayCarryFoward: {2} symbol: {3}", 
+						levelsFileDate, currentDate, MaxDayCarryForward, Instrument.MasterInstrument.Name.ToLower()), logLevel);
+					return kv;
+				}
+			}
+				
+			private bool isLevelKVValid(KeyValuePair<DateTime, List<double>> levelsKV)
+			{
+				return !levelsKV.Equals(default(KeyValuePair<DateTime, List<double>>));
+			}
+			
 			protected override void OnBarUpdate()
 			{
 				readCSV(LevelFileName);
 				if (_levelsByDate == null) return;
-				if(_levelsByDate.ContainsKey(Time[0].Date)) 
+				
+				var currentDate = Time[0].Date;
+				
+				var levelsKV = getLevelsForDate();
+				
+				if(!isLevelKVValid(levelsKV))
+				{
+					if(VerboseLogging) 
+					{
+						// TODO cargo - once caching is implemented, always log this
+						Log(String.Format("No file date for chart date: {0} maxDayCarryForward {1} symbol: {2}", 
+						currentDate, MaxDayCarryForward, Instrument.MasterInstrument.Name.ToLower()), LogLevel.Error);
+					}
+				}
+				else
 				{
 					double input0 = Input[0];
 					double upper_level = double.NaN;
 					double lower_level = double.NaN;
 					double closest_level = double.NaN;
-					var levels = _levelsByDate[Time[0].Date];
 					int counter = 0;
-					foreach(double level in levels)
+					var levelsFileDate = levelsKV.Key;
+					foreach(double level in levelsKV.Value)
 					{
+						// TODO cargo - once caching is implemented, always log this
+						if(VerboseLogging) 
+						{
+							var logLevel = levelsFileDate == currentDate ? LogLevel.Information : levelsFileDate < currentDate ? LogLevel.Warning : LogLevel.Error;
+							Log(String.Format("Using file level date: {0} for chart date: {1} maxDayCarryFoward: {2} symbol: {3}", 
+								levelsFileDate, currentDate, MaxDayCarryForward, Instrument.MasterInstrument.Name.ToLower()), logLevel);
+						}
+		
 						if(counter >= Values.Length) 
 						{
 							Log("More levels added than plots - please refresh your chart using F5", LogLevel.Error);
@@ -225,6 +285,15 @@
 
 			[Display(Name="Level Line Type", Description="Type of line (line, dot, dash, etc.)", Order=6, GroupName="Level Parameters")]
 			public DashStyleHelper LevelLineType
+			{ get; set; }
+			
+			[Display(Name="Max Day Carry Forward", Description="Use the most recent date's data if current date less than or equal to this many days ahead in time", Order=7, GroupName="Level Parameters")]
+			[Range(0, 10000)]
+			public int MaxDayCarryForward
+			{ get; set; }
+
+			[Display(Name="Verbose Logging", Description="Log more info about what the indicator is doing", Order=1, GroupName="Misc")]
+			public bool VerboseLogging
 			{ get; set; }
 
 			#endregion

--- a/MarketAnalyzerColumns/CargocultMarketAnalyzerColumns/CargocultDailyPriceLevels.cs
+++ b/MarketAnalyzerColumns/CargocultMarketAnalyzerColumns/CargocultDailyPriceLevels.cs
@@ -44,7 +44,7 @@ namespace NinjaTrader.NinjaScript.MarketAnalyzerColumns
 			{
 				// ::Filename format - Indicator will replace the text <symbol> with whatever the base symbol name is (eg spy, es, nq, meq, mes)
 				string resolved_filename = LevelsFilename.Replace("<symbol>", Instrument.MasterInstrument.Name.ToLower());
-				indicator = CargocultDailyPriceLevels(resolved_filename, 1, 100);
+				indicator = CargocultDailyPriceLevels(resolved_filename);
 			}
 		}
 


### PR DESCRIPTION
This allows the levels to be carried forward N number of days into the present. 

-  0 means that no carry forward will be applied
- Line color is custom configured to indicate that we are using carried levels vs todays levels

This change also introduces a lookup cache so that we only need to lookup the Levels data once per day.  So rather than 1440 lookups for a 1m chart we will only have 1, for example.  This was particularly relevant given that in order to do the look back (upper bound) I needed to switch from Dictionary which is a hash structure to a SortedDictionary which is a b-tree.
